### PR TITLE
Fix for draft orders not getting synched

### DIFF
--- a/src/Api/AbandonedCart/Cart.php
+++ b/src/Api/AbandonedCart/Cart.php
@@ -422,20 +422,6 @@ class Cart extends RestApi
     }
 
     /**
-     * Get the current user's cart token
-     * @return array|string|null
-     */
-    function getCartToken()
-    {
-        $cart_token = $this->retrieveCartToken();
-        if (empty($cart_token)) {
-            $cart_token = $this->generateCartToken();
-            $this->setCartToken($cart_token);
-        }
-        return apply_filters('rnoc_get_cart_token', $cart_token, $this);
-    }
-
-    /**
      * @param null $user_id
      */
     function removeCartToken($user_id = NULL)

--- a/src/Api/AbandonedCart/Checkout.php
+++ b/src/Api/AbandonedCart/Checkout.php
@@ -24,6 +24,10 @@ class Checkout extends RestApi
     {
         $draft_order = self::$woocommerce->getSession('store_api_draft_order');
         if (!empty($draft_order) && intval($draft_order) > 0) {
+            $cart_token = $this->retrieveCartToken();
+            if(empty($cart_token)) {
+               $cart_token = $this->getCartToken(); 
+            }
             $this->purchaseComplete(intval($draft_order));
         }
     }

--- a/src/Api/AbandonedCart/RestApi.php
+++ b/src/Api/AbandonedCart/RestApi.php
@@ -57,6 +57,20 @@ class RestApi
         }
     }
 
+     /**
+     * Get the current user's cart token
+     * @return array|string|null
+     */
+    function getCartToken()
+    {
+        $cart_token = $this->retrieveCartToken();
+        if (empty($cart_token)) {
+            $cart_token = $this->generateCartToken();
+            $this->setCartToken($cart_token);
+        }
+        return apply_filters('rnoc_get_cart_token', $cart_token, $this);
+    }
+
     /**
      * Set the cart token for the session
      * @param $cart_token


### PR DESCRIPTION
In certain cases, the cart token seems to be set after the purchase complete is called. It happens especially when the Checkout block is used. This should resolve that issue.